### PR TITLE
Updated unsafe packages to known safe versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - v7
-  - v6
-  - v5
-  - v4
+  - v14
+  - v12
+  - v10
 
 script:
   - npm run coverage

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "codecov": "^1.0.1",
-    "eslint": "^3.12.2",
+    "codecov": "^3.6.5",
+    "eslint": "^4.18.2",
     "eslint-config-walmart": "^1.1.0",
     "eslint-plugin-filenames": "^1.1.0",
     "istanbul": "^0.4.5",


### PR DESCRIPTION
eslint and codecov had known vulnerabilities. By updating to these versions we move to safe versions.